### PR TITLE
Kapt MVP almost working

### DIFF
--- a/src/com/facebook/buck/jvm/kotlin/AbstractKotlincVersion.java
+++ b/src/com/facebook/buck/jvm/kotlin/AbstractKotlincVersion.java
@@ -15,12 +15,14 @@
  */
 package com.facebook.buck.jvm.kotlin;
 
+import com.facebook.buck.rules.AddsToRuleKey;
 import com.facebook.buck.util.immutables.BuckStyleImmutable;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @BuckStyleImmutable
-abstract class AbstractKotlincVersion {
+abstract class AbstractKotlincVersion implements AddsToRuleKey {
+
   @Value.Parameter
   public abstract String getVersionString();
 

--- a/src/com/facebook/buck/jvm/kotlin/JarBackedReflectedKotlinc.java
+++ b/src/com/facebook/buck/jvm/kotlin/JarBackedReflectedKotlinc.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.tools.ToolProvider;
 
 public class JarBackedReflectedKotlinc implements Kotlinc {
 
@@ -174,7 +175,7 @@ public class JarBackedReflectedKotlinc implements Kotlinc {
 
       ClassLoader classLoader =
           classLoaderCache.getClassLoaderForClassPath(
-              null /* parent classloader */,
+              ToolProvider.getSystemToolClassLoader(),
               ImmutableList.copyOf(
                   compilerClassPath
                       .stream()

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/BUCK.fixture
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/BUCK.fixture
@@ -7,19 +7,6 @@ kotlin_library(
   plugins = [
       ":ap",
   ],
-  deps = [
-    ":lib",
-  ],
-)
-
-java_library(
-    name = "lib",
-    srcs = [
-        "Lib.java",
-    ],
-    plugins = [
-        ":ap",
-    ],
 )
 
 java_annotation_processor(
@@ -35,4 +22,8 @@ java_library(
     srcs = [
         "AnnotationProcessor.java",
     ],
+    resources = glob([
+        'resources/**',
+    ]),
+    resources_root = "resources"
 )

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/Lib.java
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/Lib.java
@@ -1,3 +1,0 @@
-package com.example.ap;
-
-public class Lib {}

--- a/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/test/com/facebook/buck/jvm/kotlin/testdata/kotlin_library_description/com/example/ap/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.example.ap.AnnotationProcessor


### PR DESCRIPTION
# What's done since #1584 

* `AbstractKotlincVersion` now implements `AddsToRuleKey` interface so kotlin version it is computed to the rule key
* Adds `ToolProvider.getSystemToolClassLoader()` as parent classloader to `K2JVMCompiler` (This way we don't have to provide JDK's `tools.jar` as a plugin when in kapt's generate stubs and apt stages.
* (Related to above) Removed logic to find and use JDK's `tools.jar`
* Have a default way to find kotlin jars (the code was duplicated for every jar)
* Call Javac with all generated folders as sources too, and not only the `.java` files that matched `JAVA_PATTERN`
* Call Javac with `-proc:none`, that is, pass on `JavacOptions` with empty `AnnotationProcessingParams`, this way it won't try to run apt again (kotlinc does all the apt work already, and making javac do it again crashes the compiler)
* Resolving all paths to passed to kapt plugin (this was making kapt not work on tests as it could not find the gen files properly)
* Added META-INF processor resources to the testdata AP library, kapt won't work without it

# What's still needed to do in order to have an MVP version

* Find a way to loop on all directories (kapt-generated and kapt output) and check if there were java files created, join they with the src java files to decide if javac should be called (today some kotlin tests are failing due to empty src when called only with directories)
* Related to above: Javac is currently not able to find the generated files when compiling, though the right directory is passed to it (It's the main issue right now)
* Test do not cover real AP implementations, it just generates a Java file and don't depend on any annotated class/method/field
* The ideal test should cover all the scenarios below:
  * Modify the java AP to rely on a specific annotation, generate a java class from it.
  * Create a kotlin AP that rely on a specific annotation, generate a kotlin class from it.
  * Have a java code with the annotation used by the Java AP
  * Have a java code with the annotation used by the Kotlin AP
  * Have a kotlin code with the annotation used by the Java AP
  * Have a kotlin code with the annotation used by the Kotlin AP
  * Have a java code that references created Java and kotlin code
  * Have a kotlin code that references created Java and kotlin code
